### PR TITLE
Fix the dockerfile to work on Mac

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:13-alpine
 
+RUN apk add --no-cache --virtual .gyp \
+        python \
+        make \
+        g++
+
 COPY . /opt/belvo/
 
 WORKDIR /opt/belvo/


### PR DESCRIPTION
I had to add this new line in the file. 
I constantly got a Python missing error when using Alpine on Mac.
https://github.com/nodejs/docker-node/issues/384#issuecomment-305208112