### PR TITLE
[Ruby] Use belvo-ruby gem to get a widget token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,66 @@ dmypy.json
 
 
 # End of https://www.gitignore.io/api/python
+
+# Created by https://www.gitignore.io/api/ruby
+# Edit at https://www.gitignore.io/?templates=ruby
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+### Ruby Patch ###
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+# End of https://www.gitignore.io/api/ruby

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'belvo'
+gem 'belvo', '>= 0.6.0'
 gem 'sinatra'
 gem 'httparty'
-gem "sinatra-cross_origin", "~> 0.4.0"
+gem 'sinatra-cross_origin', '~> 0.4.0'

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gem 'belvo', '>= 0.6.0'
 gem 'sinatra'
-gem 'httparty'
 gem 'sinatra-cross_origin', '~> 0.4.0'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    belvo (0.4.1)
+    belvo (0.6.0)
       faraday
       faraday_middleware
       typhoeus
@@ -33,17 +33,17 @@ GEM
       tilt (~> 2.0)
     sinatra-cross_origin (0.4.0)
     tilt (2.0.10)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  belvo
+  belvo (>= 0.6.0)
   httparty
   sinatra
   sinatra-cross_origin (~> 0.4.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -12,13 +12,6 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.12.2)
-    httparty (0.18.0)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0425)
-    multi_xml (0.6.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -41,7 +34,6 @@ PLATFORMS
 
 DEPENDENCIES
   belvo (>= 0.6.0)
-  httparty
   sinatra
   sinatra-cross_origin (~> 0.4.0)
 

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -4,7 +4,6 @@ require 'json'
 require 'belvo'
 require 'sinatra'
 require 'sinatra/cross_origin'
-require 'httparty'
 
 # Fill in your Belvo API keys - https://dashboard.belvo.co
 BELVO_SECRET_ID = ENV['BELVO_SECRET_ID']
@@ -40,7 +39,6 @@ belvo = Belvo::Client.new(
   BELVO_ENV_URL
 )
 
-auth = {:username => BELVO_SECRET_ID, :password => BELVO_SECRET_PASSWORD}
 
 before do
   if request.body
@@ -53,12 +51,10 @@ end
 # Request an access token to be used when loading the Widget
 # https://developers.belvo.co/docs/connect-widget#section--3-generate-an-access_token-
 get '/get_token' do
-  url = BELVO_ENV_URL + '/api/token/'
-  response = HTTParty.post(url, body: {id: BELVO_SECRET_ID, password: BELVO_SECRET_PASSWORD,
-    scopes: "read_institutions,write_links,read_links,delete_links"}, :basic_auth => auth)
+  response = belvo.widget_token.create
   pretty_print_response(response)
   content_type :json
-  JSON.parse(response.to_json)
+  response.to_json
 end
 
 post '/accounts' do


### PR DESCRIPTION
:question: What
---
<!-- Let us know what did you change in the code -->
- Use `belvo.widget_token.create` instead of an http call

:speech_balloon: Why
---
<!-- Are there any arguments that will help to understand these changes? Okay, put'em here... -->

<!-- If this PR Relates or Fixes an issue, please also add it --> 
- We now support requesting widget tokens