### PR TITLE
Removing CHANGEME check conditions from stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MISSING_ENV := "\n❌ Missing .env file, please use .env.example to create your own.\n"
-MISSING_KEYS := \n"❌ You need to set your own secret key credentials, please edit your .env file and replace CHANGEME with the correct value.\n"
+MISSING_KEYS := "\n❌ You need to set your own secret key credentials, please edit your .env file and replace CHANGEME with the correct value.\n"
 ALL_GOOD := "\n✅ All good!🎉🎉\n"
 
 .DEFAULT_GOAL := help
@@ -16,7 +16,7 @@ ifeq (,$(wildcard ./.env))
 	exit 1
 endif
 
-ifneq (,$(findstring CHANGEME, $(cat .env)))
+ifneq (,$(findstring CHANGEME, $(shell cat .env)))
 	@echo $(MISSING_KEYS) 
 	exit 1
 else 
@@ -35,3 +35,4 @@ up: ## Boot up quickstart app
 
 .PHONY: run
 run: check build up ## Check, build and start containers
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-MISSING_KEYS := "You need to set your own secret key credentials, please edit your .env file and replace CHANGEME with the correct value."
+MISSING_ENV := "\n❌ Missing .env file, please use .env.example to create your own.\n"
+MISSING_KEYS := \n"❌ You need to set your own secret key credentials, please edit your .env file and replace CHANGEME with the correct value.\n"
+ALL_GOOD := "\n✅ All good!🎉🎉\n"
 
 .DEFAULT_GOAL := help
 
@@ -10,10 +12,17 @@ help:  ## Shows this help message
 .PHONY: check
 check: ## Verify if you have all configured
 ifeq (,$(wildcard ./.env))
-	@echo "Missing .env file, please use .env.example to create your own."
-	exit 1;
+	@echo $(MISSING_ENV)
+	exit 1
 endif
-	if grep -q CHANGEME .env; then echo $(MISSING_KEYS); exit 1; else docker-compose config; echo "\nAll good!🎉🎉"; fi
+
+ifneq (,$(findstring CHANGEME, $(cat .env)))
+	@echo $(MISSING_KEYS) 
+	exit 1
+else 
+	@docker-compose config 
+	@echo $(ALL_GOOD)
+endif
 
 
 .PHONY: build


### PR DESCRIPTION
> After my first interview with @menecio, I stayed for a while playing with the quickstart repository. 
> It's exciting to see what you've accomplished already.

:question: What
---

I've seen that when you run the Makefile an **if condition** is being printed out (see the screenshot). I am not sure if it was intended, so I am opening this PR just in case.

I've also taken the liberty to:
- unified both conditions to gnu make syntax.
- replace the `grep` with `findstring`, since it's a standard function within `GNU make`.
- standardize how strings are defined

:speech_balloon: Why
---
- I wanted to play with the tools that you're providing.
- Even that the makefile is quite straight forward, I find more convenient to avoid mixing syntaxes.

Let me know what you think.

![image](https://user-images.githubusercontent.com/1125252/88595029-8d0c7e00-d062-11ea-85ff-931b49a92a23.png)
