### PR TITLE
[Fixed] Set BELVO_ENV in client's environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: client
     image: belvo/quickstart:client
+    environment:
+      BELVO_ENV: ${BELVO_ENV}
     ports:
     - 8080:8080
     networks:


### PR DESCRIPTION
:question: What
---
<!-- Let us know what did you change in the code -->
BELVO_ENV was not being passed to the client app when using docker compose, hence always setting sandbox as the target.

:speech_balloon: Why
---
<!-- Are there any arguments that will help to understand these changes? Okay, put'em here... -->

<!-- If this PR Relates or Fixes an issue, please also add it --> 
