### PR TITLE
[Changed] ReadMe docs now point to DevPortal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Welcome to Belvo's Quickstart application -  a handy tool to get you up and runn
 ![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
 
-Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
+Please see our [dedicated Quickstart Guide](https://developers.belvo.com/docs/quickstart-application) for instructions on how to install and deploy the project.
 
 Cheers!
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,12 @@
-# Belvo quickstart
+# Belvo Quickstart
 
-In this repository you will find an example of an app that allows you to link bank accounts through Belvo’s API using our widget. Once an account is linked, you can access the detailed information about the Accounts, Transactions and Owners.
-
-You can access all the app code and reuse it for you application.
-
-Quickstart is currently available for [Python](https://github.com/belvo-finance/quickstart/tree/master/python), [Ruby](https://github.com/belvo-finance/quickstart/tree/master/ruby) and [Node](https://github.com/belvo-finance/quickstart/tree/master/node). 
-
-Coming soon: `Go`, `Java`.
+Welcome to Belvo's Quickstart application -  a handy tool to get you up and running in less than 10 minutes 😎.
 
 ![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
-## Requirements
 
-* Docker 19+
-* docker-compose 1.25+
-* GNU Make
-* A valid Belvo secret key
+Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
 
-## Getting started
+Cheers!
 
-### 1. Clone the repository
-```
-git clone https://github.com/belvo-finance/quickstart.git
-cd quickstart/
-```
-
-### 2. Setup the Quickstart app
-Setup the Quickstart app with your sandbox API keys from the Dashboard (https://dashboard.belvo.co/)
-```
-echo "BELVO_SECRET_ID=[YOUR_ID_HERE]
-BELVO_SECRET_PASSWORD=[YOUR_PASSWORD_HERE]
-# You can choose between sandbox and production
-BELVO_ENV=sandbox
-# You can choose between python, ruby or node
-CONTEXT=python" >> .env
-```
-
-### 3. Configure the widget
-Configure the widget by adding your local URL in the Connect Widget area:
-- Go to https://dashboard.belvo.co/configuration/widget/
-- Add `http://localhost:8080` to the list of URLs
-
-### 4. Run the application
-
-```
-make run
-```
-
-
-## About Belvo
-
-Learn more about Belvo: 
-- [Developers portal](https://developers.belvo.co/)
-- [API reference](https://docs.belvo.co/)
-- [Help Center](https://support.belvo.co/hc/en-us)
-- [Belvo libraries](https://github.com/belvo-finance/)
+The Belvo Team

--- a/node/README.md
+++ b/node/README.md
@@ -5,7 +5,7 @@ Welcome to Belvo's Quickstart application -  a handy tool to get you up and runn
 ![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
 
-Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
+Please see our [dedicated Quickstart Guide](https://developers.belvo.com/docs/quickstart-application) for instructions on how to install and deploy the project.
 
 Cheers!
 

--- a/node/README.md
+++ b/node/README.md
@@ -1,44 +1,12 @@
-# Quickstart for belvo-js
+# Belvo Quickstart
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/belvo-finance/quickstart/tree/master/node)
+Welcome to Belvo's Quickstart application -  a handy tool to get you up and running in less than 10 minutes 😎.
 
-To run this application locally, first install it and then run the app with the instructions below.
+![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
-## Installing the Node.js app
 
-```
-git clone https://github.com/belvo-finance/quickstart.git
-cd quickstart/node
+Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
 
-npm install
-```
+Cheers!
 
-## Run the backend
-```
-# Start the Quickstart app with your sandbox API keys from the Dashboard
-# https://dashboard.belvo.co/
-
-BELVO_SECRET_ID='BELVO_SECRET_ID' \
-BELVO_SECRET_PASSWORD='BELVO_SECRET_PASSWORD' \
-BELVO_ENV=sandbox \
-node index.js
-```
-
-## Run the client
-```
-cd client
-npm run serve
-
-# Configure the widget to Belvo by adding your private
-# IP and the port as a new URL in the Connect Widget 
-# area (e.g: 192.139.199.12:8080)
-# https://dashboard.belvo.co/configuration/widget/
-```
-
-## Create a link
-The quickstart app is using the `Sandbox` environment by default.
-
-**You can use any combination of username and password to create a link with an institution in `Sandbox`.**
-
-Read more about creating links in sandbox in our [dedicated guide](https://developers.belvo.co/docs/test-in-sandbox#create-links-in-sandbox).
-
+The Belvo Team

--- a/python/README.md
+++ b/python/README.md
@@ -1,47 +1,12 @@
-# Quickstart for belvo-python
+# Belvo Quickstart
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/belvo-finance/quickstart/tree/master/python)
+Welcome to Belvo's Quickstart application -  a handy tool to get you up and running in less than 10 minutes 😎.
 
-To run this application locally, first install it and then run the app with the instructions below.
+![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
-## Installing the quickstart app
 
-```
-git clone https://github.com/belvo-finance/quickstart.git
-cd quickstart/python
+Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
 
-pip install -r requirements.txt
+Cheers!
 
-cd client
-npm install
-cd ..
-```
-
-## Run the backend
-```
-# Start the Quickstart app with your sandbox API keys from the Dashboard
-# https://dashboard.belvo.co/
-
-BELVO_SECRET_ID='BELVO_SECRET_ID' \
-BELVO_SECRET_PASSWORD='BELVO_SECRET_PASSWORD' \
-BELVO_ENV=sandbox \
-python server.py
-```
-
-## Run the client
-```
-cd client
-npm run serve
-
-# Configure the widget to Belvo by adding your private
-# IP and the port as a new URL in the Connect Widget 
-# area (e.g: 192.139.199.12:8080)
-# https://dashboard.belvo.co/configuration/widget/
-```
-
-## Create a link
-The quickstart app is using the `Sandbox` environment by default.
-
-**You can use any combination of username and password to create a link with an institution in `Sandbox`.**
-
-Read more about creating links in sandbox in our [dedicated guide](https://developers.belvo.co/docs/test-in-sandbox#create-links-in-sandbox).
+The Belvo Team

--- a/python/README.md
+++ b/python/README.md
@@ -5,7 +5,7 @@ Welcome to Belvo's Quickstart application -  a handy tool to get you up and runn
 ![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
 
-Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
+Please see our [dedicated Quickstart Guide](https://developers.belvo.com/docs/quickstart-application) for instructions on how to install and deploy the project.
 
 Cheers!
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,43 +1,12 @@
-# Quickstart for belvo-ruby
+# Belvo Quickstart
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/belvo-finance/quickstart/tree/master/ruby)
+Welcome to Belvo's Quickstart application -  a handy tool to get you up and running in less than 10 minutes 😎.
 
-To run this application locally, first install it and then run the app with the instructions below.
+![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
-## Installing the quickstart app
 
-``` bash
-git clone https://github.com/belvo-finance/quickstart.git
-cd quickstart/ruby
-# Install dependencies
-bundle
-```
+Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
 
-## Run the backend
-``` bash
-# Start the Quickstart app with your sandbox API keys from the Dashboard
-# https://dashboard.belvo.co/
+Cheers!
 
-BELVO_SECRET_ID='BELVO_SECRET_ID' \
-BELVO_SECRET_PASSWORD='BELVO_SECRET_PASSWORD' \
-BELVO_ENV=sandbox \
-ruby app.rb
-```
-
-## Run the client
-```
-cd client
-npm run serve
-
-# Configure the widget to Belvo by adding your private
-# IP and the port as a new URL in the Connect Widget 
-# area (e.g: 192.139.199.12:8080)
-# https://dashboard.belvo.co/configuration/widget/
-```
-
-## Create a link
-The quickstart app is using the `Sandbox` environment by default.
-
-**You can use any combination of username and password to create a link with an institution in `Sandbox`.**
-
-Read more about creating links in sandbox in our [dedicated guide](https://developers.belvo.co/docs/test-in-sandbox#create-links-in-sandbox).
+The Belvo Team

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -5,7 +5,7 @@ Welcome to Belvo's Quickstart application -  a handy tool to get you up and runn
 ![Belvo quickstart app](/assets/quickstart-screenshot.png)
 
 
-Please see our [dedicated Quickstart Guide](https://dash.readme.com/project/belvo/v1.0/docs/quickstart-application) for instructions on how to install and deploy the project.
+Please see our [dedicated Quickstart Guide](https://developers.belvo.com/docs/quickstart-application) for instructions on how to install and deploy the project.
 
 Cheers!
 


### PR DESCRIPTION
:question: What
---

Replaced all the readme files with a small paragraphing pointing to a central article in our DevPortal. 


:speech_balloon: Why
---
This is so that we have a single source of truth when it comes to using our QuickStart project (so, for example, people don't think that they have to do the Python thing separate etc). 
